### PR TITLE
Update nokogiri for security update

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,7 +64,7 @@ GEM
       jekyll-feed (~> 0.9)
       jekyll-seo-tag (~> 2.1)
     minitest (5.11.1)
-    nokogiri (1.8.1)
+    nokogiri (1.8.3)
       mini_portile2 (~> 2.3.0)
     pathutil (0.16.1)
       forwardable-extended (~> 2.6)


### PR DESCRIPTION
Changes proposed:

- Update Gemfile.lock to the latest version of nokogiri (1.8.3) instead of 1.8.1. 

This resolves a [known security vulnerability](https://nvd.nist.gov/vuln/detail/CVE-2017-18258) (which I received an email about).

<img width="602" alt="screen shot 2018-07-03 at 11 19 51 am" src="https://user-images.githubusercontent.com/2197515/42228999-5cf54362-7eb3-11e8-9f6b-3360ff4441c2.png">
